### PR TITLE
Add `MatbenchTask.__repr__`

### DIFF
--- a/benchmarks/matbench_v0.1_dummy/info.json
+++ b/benchmarks/matbench_v0.1_dummy/info.json
@@ -1,7 +1,7 @@
 {
   "authors": "Alex Dunn",
   "algorithm": "Dummy",
-  "algorithm_long": "Dummy regressor, using strategy 'mean', and Dummy regressor, using strategy 'stratified'.",
+  "algorithm_long": "Dummy regressor, using strategy 'mean', and Dummy classifier, using strategy 'stratified'.",
   "bibtex_refs": "@article{Dunn2020,\n  doi = {10.1038/s41524-020-00406-3},\n  url = {https://doi.org/10.1038/s41524-020-00406-3},\n  year = {2020},\n  month = sep,\n  publisher = {Springer Science and Business Media {LLC}},\n  volume = {6},\n  number = {1},\n  author = {Alexander Dunn and Qi Wang and Alex Ganose and Daniel Dopp and Anubhav Jain},\n  title = {Benchmarking materials property prediction methods: the Matbench test set and Automatminer reference algorithm},\n  journal = {npj Computational Materials}\n}",
   "notes": "No notes.",
   "requirements": {"python":  ["scikit-learn==0.24.1", "numpy==1.20.1", "matbench==0.1.0"]}

--- a/benchmarks/matbench_v0.1_dummy/notebook.ipynb
+++ b/benchmarks/matbench_v0.1_dummy/notebook.ipynb
@@ -258,7 +258,7 @@
     "        \n",
     "        # Record our predictions into the benchmark object\n",
     "        # you can optionally add parameters corresponding to the particular model in this fold\n",
-    "        # if particular hyperparameters or configurations are chosen based on training/vaidation\n",
+    "        # if particular hyperparameters or configurations are chosen based on training/validation\n",
     "        task.record(fold, predictions, params={param: getattr(model, param)})\n",
     "        "
    ]
@@ -564,14 +564,6 @@
     "# Save the valid benchmark to file to include with your submission\n",
     "mb.to_file(\"results.json.gz\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "computational-oklahoma",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/matbench/data_ops.py
+++ b/matbench/data_ops.py
@@ -102,7 +102,7 @@ def score_array(true_array, pred_array, task_type):
         metrics = CLF_METRICS
     else:
         raise ValueError(
-            f"'task_type' must be on of {[REG_KEY, CLF_KEY]}, not '{task_type}'"
+            f"'task_type' must be one of {[REG_KEY, CLF_KEY]}, not '{task_type}'"
         )
 
     for metric in metrics:

--- a/matbench/task.py
+++ b/matbench/task.py
@@ -110,6 +110,16 @@ class MatbenchTask(MSONable, MSONable2File):
         self.folds = self.folds_nums
         self.results = RecursiveDotDict({})
 
+    def __repr__(self) -> str:
+        keys = "input_type mad n_samples target task_type unit".split()
+
+        md_str = ",\n  ".join(f"{k}={self.metadata[k]}" for k in keys)
+
+        return (
+            f"{type(self).__name__}(\n  dataset_name={self.dataset_name},\n  version"
+            f"={self.benchmark_name.replace('matbench_v', '')},\n  {md_str},\n)"
+        )
+
     def _get_data_from_df(self, ids, as_type):
         """Private function to get fold data from the task dataframe.
 

--- a/matbench/task.py
+++ b/matbench/task.py
@@ -514,7 +514,7 @@ class MatbenchTask(MSONable, MSONable2File):
         regression problems.
 
         Returns:
-            (dict): A dictionary of all the scores for this
+            (dict): A dictionary of all the scores for this task.
         """
         metric_keys = (
             REG_METRICS if self.metadata.task_type == REG_KEY else CLF_METRICS

--- a/scripts/mvb01_generate_validation.py
+++ b/scripts/mvb01_generate_validation.py
@@ -1,17 +1,21 @@
-import os
-import json
-
+import pandas as pd
 from monty.serialization import dumpfn
 from sklearn.model_selection import KFold, StratifiedKFold
 
+from matbench.constants import (
+    CLF_KEY,
+    REG_KEY,
+    TEST_KEY,
+    TRAIN_KEY,
+    VALIDATION_METADATA_KEY,
+    VALIDATION_SPLIT_KEY,
+)
 from matbench.data_ops import load
-from matbench.constants import REG_KEY, CLF_KEY, VALIDATION_METADATA_KEY, VALIDATION_SPLIT_KEY, TRAIN_KEY, TEST_KEY
 from matbench.metadata import mbv01_metadata
 
-import pandas as pd
-pd.set_option('display.max_rows', 500)
-pd.set_option('display.max_columns', 500)
-pd.set_option('display.width', 1000)
+pd.set_option("display.max_rows", 500)
+pd.set_option("display.max_columns", 500)
+pd.set_option("display.width", 1000)
 
 
 def matbench_v01():
@@ -50,9 +54,9 @@ def matbench_v01():
         VALIDATION_METADATA_KEY: {
             "n_splits": 5,
             "random_state": 18012019,
-            "shuffle": True
+            "shuffle": True,
         },
-        VALIDATION_SPLIT_KEY: None
+        VALIDATION_SPLIT_KEY: None,
     }
 
     kfold_config = d[VALIDATION_METADATA_KEY]
@@ -69,7 +73,8 @@ def matbench_v01():
             kfold = StratifiedKFold(**kfold_config)
         else:
             raise ValueError(
-                f"'problem_type' must be one of {[REG_KEY, CLF_KEY]}, not '{task_type}'.")
+                f"'problem_type' must be one of {[REG_KEY, CLF_KEY]}, not '{task_type}'."
+            )
 
         df = load(ds)
         print(df)
@@ -93,8 +98,6 @@ def matbench_v01():
 
     print("Writing file...")
     dumpfn(d, "../matbench/matbench_v0.1_validation.json")
-
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```py
from matbench import MatbenchBenchmark

for task in MatbenchBenchmark().tasks:
    print(task)
```

### Output Before

```py
<matbench.task.MatbenchTask object at 0x2b2068e75c40>
<matbench.task.MatbenchTask object at 0x2b2068e75c70>
<matbench.task.MatbenchTask object at 0x2b2054b0d490>
<matbench.task.MatbenchTask object at 0x2b2054ba64c0>
<matbench.task.MatbenchTask object at 0x2b2054ba62e0>
<matbench.task.MatbenchTask object at 0x2b20821fdbb0>
<matbench.task.MatbenchTask object at 0x2b20821fdb20>
<matbench.task.MatbenchTask object at 0x2b20821fda90>
<matbench.task.MatbenchTask object at 0x2b20821fda00>
<matbench.task.MatbenchTask object at 0x2b20821fd940>
<matbench.task.MatbenchTask object at 0x2b20821fd820>
<matbench.task.MatbenchTask object at 0x2b20821fdc40>
<matbench.task.MatbenchTask object at 0x2b20821fdcd0>
```

### After

Happy to make changes. E.g. we could round the `mad` to 2 decimals or wrap strings in quotes, i.e. `task_type='regression'`.

```py
MatbenchTask(
  dataset_name=matbench_dielectric,
  version=0.1,
  input_type=structure,
  mad=0.808534704217072,
  n_samples=4764,
  target=n,
  task_type=regression,
  unit=unitless,
)
MatbenchTask(
  dataset_name=matbench_expt_gap,
  version=0.1,
  input_type=composition,
  mad=1.1432002429044061,
  n_samples=4604,
  target=gap expt,
  task_type=regression,
  unit=eV,
)
MatbenchTask(
  dataset_name=matbench_expt_is_metal,
  version=0.1,
  input_type=composition,
  mad={},
  n_samples=4921,
  target=is_metal,
  task_type=classification,
  unit=None,
)
MatbenchTask(
  dataset_name=matbench_glass,
  version=0.1,
  input_type=composition,
  mad={},
  n_samples=5680,
  target=gfa,
  task_type=classification,
  unit=None,
)
MatbenchTask(
  dataset_name=matbench_jdft2d,
  version=0.1,
  input_type=structure,
  mad=67.20200406491116,
  n_samples=636,
  target=exfoliation_en,
  task_type=regression,
  unit=meV/atom,
)
MatbenchTask(
  dataset_name=matbench_log_gvrh,
  version=0.1,
  input_type=structure,
  mad=0.29313828328604646,
  n_samples=10987,
  target=log10(G_VRH),
  task_type=regression,
  unit=log10(GPa),
)
MatbenchTask(
  dataset_name=matbench_log_kvrh,
  version=0.1,
  input_type=structure,
  mad=0.2896736342937069,
  n_samples=10987,
  target=log10(K_VRH),
  task_type=regression,
  unit=log10(GPa),
)
MatbenchTask(
  dataset_name=matbench_mp_e_form,
  version=0.1,
  input_type=structure,
  mad=1.0059220443295362,
  n_samples=132752,
  target=e_form,
  task_type=regression,
  unit=eV/atom,
)
MatbenchTask(
  dataset_name=matbench_mp_gap,
  version=0.1,
  input_type=structure,
  mad=1.3271449960162496,
  n_samples=106113,
  target=gap pbe,
  task_type=regression,
  unit=eV,
)
MatbenchTask(
  dataset_name=matbench_mp_is_metal,
  version=0.1,
  input_type=structure,
  mad={},
  n_samples=106113,
  target=is_metal,
  task_type=classification,
  unit=None,
)
MatbenchTask(
  dataset_name=matbench_perovskites,
  version=0.1,
  input_type=structure,
  mad=0.5659924184827462,
  n_samples=18928,
  target=e_form,
  task_type=regression,
  unit=eV/unit cell,
)
MatbenchTask(
  dataset_name=matbench_phonons,
  version=0.1,
  input_type=structure,
  mad=323.78696979348734,
  n_samples=1265,
  target=last phdos peak,
  task_type=regression,
  unit=cm^-1,
)
MatbenchTask(
  dataset_name=matbench_steels,
  version=0.1,
  input_type=composition,
  mad=229.37426857330706,
  n_samples=312,
  target=yield strength,
  task_type=regression,
  unit=MPa,
)
```
