### PR TITLE
Add initial CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,32 @@
+# YAML 1.2
+# Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
+cff-version: 1.2.0
+message: If you use this software, please cite the following article and the appropriate version of the archived data.
+title: "Matbench: Benchmarks for materials science property prediction"
+authors:
+- given-names: Alex
+  family-names: Dunn
+  affiliation: UC Berkeley
+  orcid: https://orcid.org/0000-0002-8567-1879
+repository-code: https://github.com/materialsproject/matbench
+url: https://matbench.materialsproject.org/
+license: MIT
+preferred-citation:
+  type: article
+  authors:
+  - given-names: A.
+    family-names: Dunn
+  - given-names: Q.
+    family-names: Wang 
+  - given-names: A.
+    family-names: Ganose
+  - given-names: D.
+    family-names: Dopp 
+  - given-names: A.
+    family-names: Jain 
+  doi: "10.1038/s41524-020-00406-3"
+  journal: "npj Computational Materials"
+  title: "Benchmarking Materials Property Prediction Methods: The Matbench Test Set and Automatminer Reference Algorithm"
+  volume: 6
+  number: 138
+  year: 2020


### PR DESCRIPTION
re: #156.

Just added @ardunn as the author for this repo now. Zenodo has a separate "contributors" field but not sure how this maps to the CFF schema (probably just as additional `authors` - not sure how you would feel about that!).

The main goal from #156 is to automatically archive releases to Zenodo. This file will automatically be used by Zenodo to populate the metadata, otherwise for each release, Zenodo will scrape the repo metadata and include all contributors as authors, and will also miss the related DOIs of the paper, and any additional info you want to provide (ORCID, custom titles etc.).

Outstanding issue: there's no satisfactory way to update the CITATION.cff with the latest versioned Zenodo DOI. Can either just use the "concept DOI" for all versions in the citation file, then describe how to cite the versioned DOI in the text, or try to set up some additional procedure that would use the Zenodo API to add one commit after release that bumps the versioned DOI.