### PR TITLE
Fix `site-packages` namespace pollution

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install wheel setuptools
-          pip install -e . -r requirements.txt
+          pip install -e .
           pip install -r requirements-dev.txt
           coverage run -m unittest discover
           coverage json
@@ -63,6 +63,6 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install wheel setuptools
-        pip install -e . -r requirements.txt
+        pip install -e .
         pip install -r requirements-dev.txt
         python -m unittest scripts/test_submission.py

--- a/.github/workflows/rebuild_website.yml
+++ b/.github/workflows/rebuild_website.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install wheel setuptools
-          pip install -e . -r requirements.txt
+          pip install -e .
           pip install -r requirements-dev.txt
           pip install -r requirements-docs.txt
           python scripts/rebuild_docs.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-matminer==0.7.4
-scipy==1.9.0
-monty==2022.4.26
-scikit-learn==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author="Alex Dunn, Anubhav Jain",
     author_email="ardunn@lbl.gov",
     license="modified BSD",
-    packages=find_packages(include="matbench/*"),
+    packages=find_packages(include=["matbench*"], exclude=["*tests"]),
     package_data={"matbench": ["*.json"]},
     install_requires=[
         "matminer>=0.7.4",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 VERSION_FILE = os.path.join(MODULE_DIR, "matbench/constants.py")
 token = "VERSION = "
 with open(VERSION_FILE) as f:
-    version = None
     for line in f.readlines():
         if token in line:
             version = line.replace(token, "").strip()
@@ -16,23 +15,22 @@ with open(VERSION_FILE) as f:
 version = version.replace('"', "")
 
 
-if __name__ == "__main__":
-    setup(
-        name="matbench",
-        version=version,
-        description="a machine learning benchmark for materials science",
-        long_description="A machine learning benchmark for materials science. "
-        "https://github.com/materialsproject/matbench",
-        url="https://github.com/materialsproject/matbench",
-        author="Alex Dunn, Anubhav Jain",
-        author_email="ardunn@lbl.gov",
-        license="modified BSD",
-        packages=find_packages(include="matbench"),
-        package_data={"matbench": ["*.json"]},
-        install_requires=[
-            "matminer>=0.7.4",
-            "scipy>=1.9.0",
-            "monty>=2022.4.26",
-            "scikit-learn>=1.0.1",
-        ],
-    )
+setup(
+    name="matbench",
+    version=version,
+    description="a machine learning benchmark for materials science",
+    long_description="A machine learning benchmark for materials science. "
+    "https://github.com/materialsproject/matbench",
+    url="https://github.com/materialsproject/matbench",
+    author="Alex Dunn, Anubhav Jain",
+    author_email="ardunn@lbl.gov",
+    license="modified BSD",
+    packages=find_packages(include="matbench/*"),
+    package_data={"matbench": ["*.json"]},
+    install_requires=[
+        "matminer>=0.7.4",
+        "scipy>=1.9.0",
+        "monty>=2022.4.26",
+        "scikit-learn>=1.0.1",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ import os
 from setuptools import find_packages, setup
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
-with open(os.path.join(MODULE_DIR, "requirements.txt")) as f:
-    requirements = f.read().replace(" ", "").split("\n")
 
 # source of version is in the constants file
 VERSION_FILE = os.path.join(MODULE_DIR, "matbench/constants.py")
@@ -31,5 +29,10 @@ if __name__ == "__main__":
         license="modified BSD",
         packages=find_packages(include="matbench"),
         package_data={"matbench": ["*.json"]},
-        install_requires=requirements,
+        install_requires=[
+            "matminer>=0.7.4",
+            "scipy>=1.9.0",
+            "monty>=2022.4.26",
+            "scikit-learn>=1.0.1",
+        ],
     )

--- a/setup.py
+++ b/setup.py
@@ -15,29 +15,21 @@ with open(VERSION_FILE) as f:
         if token in line:
             version = line.replace(token, "").strip()
 # Double quotes are contained in the read line, remove them
-version = version.replace("\"", "")
+version = version.replace('"', "")
 
 
 if __name__ == "__main__":
     setup(
-        name='matbench',
+        name="matbench",
         version=version,
-        description='a machine learning benchmark for materials science',
+        description="a machine learning benchmark for materials science",
         long_description="A machine learning benchmark for materials science. "
-                         "https://github.com/materialsproject/matbench",
-        url='https://github.com/materialsproject/matbench',
-        author=['Alex Dunn', 'Anubhav Jain'],
-        author_email='ardunn@lbl.gov',
-        license='modified BSD',
-        packages=find_packages(where="."),
-        package_data={
-            "matbench": ["*.json"],
-            "matbench.tests": ["*.json"]
-        },
-        zip_safe=False,
+        "https://github.com/materialsproject/matbench",
+        url="https://github.com/materialsproject/matbench",
+        author="Alex Dunn, Anubhav Jain",
+        author_email="ardunn@lbl.gov",
+        license="modified BSD",
+        packages=find_packages(include="matbench"),
+        package_data={"matbench": ["*.json"]},
         install_requires=requirements,
-        extras_require={},
-        test_suite='matbench',
-        tests_require='tests',
-        include_package_data=True
     )


### PR DESCRIPTION
While uninstalling PyPI `matbench` in favor of editable install, I noticed `matbench` (probably inadvertently?) creates a scripts directory in `site-packages`:

```sh
pip uninstall matbench             
Found existing installation: matbench 0.5
Uninstalling matbench-0.5:
  Would remove:
    /Users/janosh/.venv/py310/lib/python3.10/site-packages/matbench-0.5.dist-info/*
    /Users/janosh/.venv/py310/lib/python3.10/site-packages/matbench/*
    /Users/janosh/.venv/py310/lib/python3.10/site-packages/scripts/*
Proceed (Y/n)? y
```

To fix this in `setup.py` I changed:

```diff
- packages=find_packages(where="."),
+ packages=find_packages(include=["matbench*"], exclude=["*tests"]),
```