### PR TITLE
Adding the formula used to calculate Scaled error for classification tasks to the docs

### DIFF
--- a/scripts/doc_snippets/index_0.md
+++ b/scripts/doc_snippets/index_0.md
@@ -4,3 +4,8 @@ $$
 \text{Scaled Error} = \frac{\text{MAE}}{\text{MAD}} = \frac{\sum_i^N | y_i - y_i^{pred} |}{\sum_i^N | y_i - \bar{y} | }
 $$
 
+While, scaled errors for classifications are assessed as:
+
+$$
+\text{Scaled Error} = \frac{1 - \text{ROCAUC}}{0.5}
+$$


### PR DESCRIPTION
## Core code/data/docs changes

### Brief description of changes

- The website only displays the Scaled error metric for regression tasks. In order to make the website more comprehensive, I have created a pull request to add the formula for evaluating the Scaled error metric for classification tasks as well.